### PR TITLE
Add dailies attributes and extra battery stats

### DIFF
--- a/examples/homeassistant/README.md
+++ b/examples/homeassistant/README.md
@@ -78,6 +78,11 @@ sensor:
         icon_template: mdi:run
         value_template: '{{ state_attr("device_tracker.whistle_charlie", "activity_calories") | round(1) }}'
         unit_of_measurement: 'calories'
+      charlie_battery_days_left:
+        friendly_name: "Battery Days Left"
+        icon_template: mdi:calendar-clock
+        value_template: '{{ state_attr("device_tracker.whistle_charlie", "battery_days_left") }}'
+        unit_of_measurement: 'days'
       charlie_battery_24h_wifi_usage:
         friendly_name: "Battery WiFi Usage"
         icon_template: mdi:wifi
@@ -113,5 +118,6 @@ views:
                   - sensor.charlie_calories
                   - sensor.charlie_battery_24h_wifi_usage
                   - sensor.charlie_battery_24h_cell_usage
+                  - sensor.charlie_battery_days_left
 
 ```

--- a/examples/homeassistant/README.md
+++ b/examples/homeassistant/README.md
@@ -68,6 +68,26 @@ sensor:
         icon_template: mdi:battery
         value_template: '{{ state_attr("device_tracker.whistle_charlie", "battery_level") }}'
         unit_of_measurement: '%'
+      charlie_distance:
+        friendly_name: "Distance"
+        icon_template: mdi:map-marker-distance
+        value_template: '{{ state_attr("device_tracker.whistle_charlie", "activity_distance") | round(1) }}'
+        unit_of_measurement: 'miles'
+      charlie_calories:
+        friendly_name: "Calories"
+        icon_template: mdi:run
+        value_template: '{{ state_attr("device_tracker.whistle_charlie", "activity_calories") | round(1) }}'
+        unit_of_measurement: 'calories'
+      charlie_battery_24h_wifi_usage:
+        friendly_name: "Battery WiFi Usage"
+        icon_template: mdi:wifi
+        value_template: '{{ state_attr("device_tracker.whistle_charlie", "24h_battery_wifi_usage") }}'
+        unit_of_measurement: '%'
+      charlie_battery_24h_cell_usage:
+        friendly_name: "Battery Cellular Usage"
+        icon_template: mdi:cellphone-basic
+        value_template: '{{ state_attr("device_tracker.whistle_charlie", "24h_battery_cellular_usage") }}'
+        unit_of_measurement: '%'
 ```
 
 Then, use these templates in 'ui-lovelace.yaml' -- 
@@ -89,5 +109,9 @@ views:
                   - sensor.charlie_goal_streak
                   - sensor.charlie_active_minutes
                   - sensor.charlie_rest_minutes
+                  - sensor.charlie_distance
+                  - sensor.charlie_calories
+                  - sensor.charlie_battery_24h_wifi_usage
+                  - sensor.charlie_battery_24h_cell_usage
 
 ```

--- a/examples/homeassistant/device_tracker.py
+++ b/examples/homeassistant/device_tracker.py
@@ -72,6 +72,8 @@ class WhistleScanner:
             _LOGGER.warning("No Pets found")
             return
         for pet in pets['pets']:
+            dailies = await self._client.get_dailies(pet['id'])
+            device = await self._client.get_device(pet['device']['serial_number'])
             attributes = {
                 'name': pet['name'],
                 'battery_level': pet['device']['battery_level'],
@@ -80,7 +82,12 @@ class WhistleScanner:
                 'activity_streak': pet['activity_summary']['current_streak'],
                 'activity_minutes_active': pet['activity_summary']['current_minutes_active'],
                 'activity_minutes_rest': pet['activity_summary']['current_minutes_rest'],
-                'activity_goal': pet['activity_summary']['current_activity_goal']['minutes']
+                'activity_goal': pet['activity_summary']['current_activity_goal']['minutes'],
+                'activity_distance': dailies['dailies'][0]['distance'],
+                'activity_calories': dailies['dailies'][0]['calories'],
+                'battery_days_left': device['device']['battery_stats']['battery_days_left'],
+                '24h_battery_save_usage': round(((float(device['device']['battery_stats']['prior_usage_minutes']['24h']['power_save_mode']) / 1440) * 100), 0),
+                '24h_battery_cellular_usage': round(((float(device['device']['battery_stats']['prior_usage_minutes']['24h']['cellular']) / 1440) * 100), 0)
             }
             if self._preferred_picture in pet['profile_photo_url_sizes']:
                 attributes['picture'] = pet['profile_photo_url_sizes'][self._preferred_picture]
@@ -91,4 +98,4 @@ class WhistleScanner:
                     pet['last_location']['longitude']
                 ),
                 attributes = attributes,
-                icon='mdi:view-grid')
+                icon='mdi:dog')

--- a/examples/homeassistant/device_tracker.py
+++ b/examples/homeassistant/device_tracker.py
@@ -86,7 +86,7 @@ class WhistleScanner:
                 'activity_distance': dailies['dailies'][0]['distance'],
                 'activity_calories': dailies['dailies'][0]['calories'],
                 'battery_days_left': device['device']['battery_stats']['battery_days_left'],
-                '24h_battery_save_usage': round(((float(device['device']['battery_stats']['prior_usage_minutes']['24h']['power_save_mode']) / 1440) * 100), 0),
+                '24h_battery_wifi_usage': round(((float(device['device']['battery_stats']['prior_usage_minutes']['24h']['power_save_mode']) / 1440) * 100), 0),
                 '24h_battery_cellular_usage': round(((float(device['device']['battery_stats']['prior_usage_minutes']['24h']['cellular']) / 1440) * 100), 0)
             }
             if self._preferred_picture in pet['profile_photo_url_sizes']:

--- a/examples/homeassistant/manifest.json
+++ b/examples/homeassistant/manifest.json
@@ -5,5 +5,5 @@
     "documentation": "https://github.com/Fusion/pywhistle/tree/master/examples/homeassistant",
     "dependencies": [],
     "codeowners": ["@fusion"],
-    "requirements": ["pywhistle==0.0.2"]
+    "requirements": ["git+https://github.com/Fusion/pywhistle@master#pywhistle==0.0.3"]
 }

--- a/examples/homeassistant/manifest.json
+++ b/examples/homeassistant/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "whistle",
     "name": "Whistle GPS and Activity Tracker",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "documentation": "https://github.com/Fusion/pywhistle/tree/master/examples/homeassistant",
     "dependencies": [],
     "codeowners": ["@fusion"],

--- a/pywhistle/client.py
+++ b/pywhistle/client.py
@@ -26,10 +26,10 @@ class Client:
             "Host": config['remote_host'],
             "Content-Type": "application/json",
             "Connection": "keep-alive",
-            "Accept": "application/vnd.whistle.com.v4+json",
-            "Accept-Language": "en-us",
+            "Accept": "application/vnd.whistle.com.v5+json",
+            "Accept-Language": "en",
             "Accept-Encoding": "br, gzip, deflate",
-            "User-Agent": "Winston/2.5.3 (iPhone; iOS 12.0.1; Build:1276; Scale/2.0)",
+            "User-Agent": "Winston/3.9.0 (iPhone; iOS 13.5; Build:2399; Scale/3.0)",
             "Authorization": "Bearer %s" % token
     }
 
@@ -95,6 +95,13 @@ class Client:
     async def get_pets(self):
         return await self.get_resource(self._config, self._token, 'pets')
 
+    """
+    Returns:
+       device: dictionary of
+          model_id, serial_number, battery_stats, etc
+    """
+    async def get_device(self, serial_number):
+        return await self.get_resource(self._config, self._token, 'devices/%s' % serial_number)
 
     """
     Returns:

--- a/pywhistle/client.py
+++ b/pywhistle/client.py
@@ -49,8 +49,8 @@ class Client:
             ) -> dict:
         if not headers:
             headers = {}
-        """Need to specify encoding when getting Achievements endpoint"""
-        if "achievements" in resource:
+        """Need to specify encoding when getting Achievements or Places endpoint"""
+        if "achievements" or "places" in resource:
             async with self._websession.request(
                     method,
                     self.url(config, resource),

--- a/pywhistle/client.py
+++ b/pywhistle/client.py
@@ -49,6 +49,15 @@ class Client:
             ) -> dict:
         if not headers:
             headers = {}
+        """Need to specify encoding when getting Achievements endpoint"""
+        if "achievements" in resource:
+            async with self._websession.request(
+                    method,
+                    self.url(config, resource),
+                    headers=headers,
+                    data=data) as r:
+                r.raise_for_status()
+                return await r.json(encoding='UTF-8')
         async with self._websession.request(
                 method,
                 self.url(config, resource),
@@ -174,6 +183,17 @@ class Client:
     """
     async def get_dailies_day(self, pet_id, day_id):
         return await self.get_resource(self._config, self._token, "pets/%s/dailies/%s" % (pet_id, day_id))
+
+    """
+    Returns:
+        daily_items: array of dictionaries
+                type: event type
+                title: event title
+                start_time: in UTC
+                end_time: string in UTC
+    """
+    async def get_dailies_daily_items(self, pet_id, day_id):
+        return await self.get_resource(self._config, self._token, "pets/%s/dailies/%s/daily_items" % (pet_id, day_id))
 
 
     """

--- a/pywhistle/client.py
+++ b/pywhistle/client.py
@@ -106,6 +106,15 @@ class Client:
 
     """
     Returns:
+        pet: dictionary of
+             id, gender, name, etc for single pet
+    """
+
+    async def get_pet(self, pet_id):
+        return await self.get_resource(self._config, self._token, 'pets/%s' % pet_id)
+
+    """
+    Returns:
        device: dictionary of
           model_id, serial_number, battery_stats, etc
     """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def get_readme_content():
 
 setup(
     name = 'pywhistle',
-    version = '0.0.2',
+    version = '0.0.3',
     description = 'Unofficial Whistle 3 Device API',
     author = 'Chris F Ravenscroft',
     author_email = 'chris@voilaweb.com',


### PR DESCRIPTION
Added "get_device" function to client.py in order to retrieve extended battery info

Added attributes:

- 'activity_distance' = distance covered today
- 'activity_calories' = calories burned today
- 'battery_days_left' = approximation of the amount of days left before battery is empty
- '24h_battery_wifi_usage' = percent of time, for the last 24hrs, that the device used a WiFi connection
- '24h_battery_cellular_usage' = percent of time, for the last 24hrs, that the device used a Cellular connection

Updated Home Assistant sensor examples.

Updated manifest.json file:
- bumped version to 1.1.0
- requirements points to Fusion/pywhistle github repo - this is in case you don't want to push pywhistle 0.0.3 to PyPi. In this format, HA will pull the updated client.py changes from your repo instead of looking for it on PyPi. If you do end up pushing the changes to PyPi, feel free to change the requirement field.