### PR TITLE
Change repo url from ssh to https to allow for anonymous cloning

### DIFF
--- a/examples/homeassistant/README.md
+++ b/examples/homeassistant/README.md
@@ -12,7 +12,7 @@ The commands below should create the correct hierarchy while not downloading the
 ```
 # Modify the following line to replace the path after "cd" to match your folder structure
 cd home-assistant/config/custom_components
-git clone --depth=1 git@github.com:Fusion/pywhistle.git --no-checkout
+git clone --depth=1 https://github.com/Fusion/pywhistle.git --no-checkout
 cd pywhistle
 git checkout master -- examples/homeassistant
 cd ..


### PR DESCRIPTION
If you use ssh without a github ssh key it doesn't work, anonymous cloning is only available via https afaik